### PR TITLE
Add case insensitive support to fromString

### DIFF
--- a/lib/enum_to_string.dart
+++ b/lib/enum_to_string.dart
@@ -18,7 +18,7 @@ class EnumToString {
   static fromString<T>(List<T> enumValues, String value) {
     if (value == null) return null;
 
-    return enumValues.singleWhere(
+    return enumValues.firstWhere(
         (enumItem) => EnumToString.parse(enumItem) == value,
         orElse: () => null);
   }

--- a/lib/enum_to_string.dart
+++ b/lib/enum_to_string.dart
@@ -19,7 +19,7 @@ class EnumToString {
     if (value == null) return null;
 
     return enumValues.firstWhere(
-        (enumItem) => EnumToString.parse(enumItem) == value,
+        (enumItem) => EnumToString.parse(enumItem)?.toLowerCase() == value?.toLowerCase(),
         orElse: () => null);
   }
 }


### PR DESCRIPTION
- Add case insensitive support to fromString, that is used many times to map from network services that results in case insensitive values.

- Use firstWhere instead of singleWhere to prevent error when finds more than one value.
I know that enums don't have duplicated values, but it is a good practice.