### PR TITLE
Prevent errors

### DIFF
--- a/lib/enum_to_string.dart
+++ b/lib/enum_to_string.dart
@@ -16,9 +16,9 @@ class EnumToString {
   }
 
   static fromString<T>(List<T> enumValues, String value) {
-    if (value == null) return null;
+    if (value == null || enumValues == null) return null;
 
-    return enumValues.singleWhere(
+    return enumValues.firstWhere(
         (enumItem) => EnumToString.parse(enumItem) == value,
         orElse: () => null);
   }


### PR DESCRIPTION
- Check enumValues to prevent null value
- Use firstWhere instead of singleWhere to prevent error when finds more than one value. I know that enums don't have duplicated values, but it is a good practice.