### PR TITLE
throws an exception when parsing a non enum item

### DIFF
--- a/lib/enum_to_string.dart
+++ b/lib/enum_to_string.dart
@@ -2,10 +2,29 @@ library enum_to_string;
 
 import 'camel_case_to_words.dart';
 
-/// A Calculator.
+class NotAnEnumException implements Exception {
+  dynamic value;
+
+  NotAnEnumException(this.value);
+
+  @override
+  String toString() =>
+      '${value.toString()} of type ${value.runtimeType.toString()} is not an enum item.';
+}
+
 class EnumToString {
+  static bool _isEnumItem(enumItem) {
+    final splitted_enum = enumItem.toString().split('.');
+    return splitted_enum.length > 1 &&
+        splitted_enum[0] == enumItem.runtimeType.toString();
+  }
+
   static String parse(enumItem, {bool camelCase = false}) {
     if (enumItem == null) return null;
+
+    if (!_isEnumItem(enumItem)) {
+      throw NotAnEnumException(enumItem);
+    }
     final _tmp = enumItem.toString().split('.')[1];
     return !camelCase ? _tmp : camelCaseToWords(_tmp);
   }

--- a/test/enum_to_string_test.dart
+++ b/test/enum_to_string_test.dart
@@ -104,4 +104,11 @@ void main() {
     expect(EnumToString.toList(TestEnum.values, camelCase: true)[1], 'Value 2');
     expect(EnumToString.toList(null, camelCase: true), null);
   });
+
+  test('it should throw proper exception', () {
+    expect(() => EnumToString.parse('SomeEnum.SomeValue'),
+        throwsA(TypeMatcher<NotAnEnumException>()));
+    expect(() => EnumToString.parse('SomeString'),
+        throwsA(TypeMatcher<NotAnEnumException>()));
+  });
 }


### PR DESCRIPTION
Fixes #18.

Throws a `NotAnEnumException` whenever `EnumToString.parse` receives a non enum item.
Also added tests for this behavior.

Let me know if you want me to change wording, conventions, names or code.