### PR TITLE
Migrate to Null Safety 🚀

### DIFF
--- a/lib/camel_case_to_words.dart
+++ b/lib/camel_case_to_words.dart
@@ -50,7 +50,7 @@ String camelCaseToWords(String subject,
     return '';
   }
 
-  RegExp pattern;
+  late RegExp pattern;
 
   if (customPattern is String) {
     pattern = RegExp(customPattern);
@@ -60,10 +60,10 @@ String camelCaseToWords(String subject,
 
   final words = pattern.allMatches(subject).map((m) => m.group(0)).toList();
 
-  words[0] = words[0][0].toUpperCase() + words[0].substring(1);
+  words[0] = words[0]![0].toUpperCase() + words[0]!.substring(1);
 
   for (var i = 1; i < words.length; i++) {
-    words[i] = words[i].toLowerCase();
+    words[i] = words[i]!.toLowerCase();
   }
 
   return words.join(' ');

--- a/lib/enum_to_string.dart
+++ b/lib/enum_to_string.dart
@@ -1,6 +1,7 @@
 library enum_to_string;
 
 import 'camel_case_to_words.dart';
+import 'package:collection/collection.dart' show IterableExtension;
 
 class EnumToString {
   static bool _isEnumItem(enumItem) {
@@ -16,7 +17,7 @@ class EnumToString {
   ///
   /// If you pass in the option [camelCase]=true it will convert it to words
   /// So TestEnum.valueOne will become Value One
-  static String convertToString(enumItem, {bool camelCase = false}) {
+  static String? convertToString(enumItem, {bool camelCase = false}) {
     if (enumItem == null) return null;
 
     assert(_isEnumItem(enumItem),
@@ -27,14 +28,14 @@ class EnumToString {
 
   @Deprecated(
       'Renamed function to EnumToString.convertToString to make it clearer')
-  static String parse(enumItem, {bool camelCase = false}) =>
+  static String? parse(enumItem, {bool camelCase = false}) =>
       convertToString(enumItem, camelCase: camelCase);
 
   /// An alias for parse(item, camelCase: true)
   ///
   @Deprecated(
       'Deprecated in favour of using convertToString(item, camelCase: true)')
-  static String parseCamelCase(enumItem) {
+  static String? parseCamelCase(enumItem) {
     return EnumToString.convertToString(enumItem, camelCase: true);
   }
 
@@ -46,16 +47,15 @@ class EnumToString {
   /// Example final result = EnumToString.fromString(TestEnum.values, "valueOne")
   /// result == TestEnum.valueOne //true
   ///
-  static T fromString<T>(List<T> enumValues, String value,
+  static T? fromString<T>(List<T>? enumValues, String? value,
       {bool camelCase = false}) {
     if (value == null || enumValues == null) return null;
 
-    return enumValues.singleWhere(
+    return enumValues.singleWhereOrNull(
         (enumItem) =>
             EnumToString.convertToString(enumItem, camelCase: camelCase)
                 ?.toLowerCase() ==
-            value?.toLowerCase(),
-        orElse: () => null);
+            value.toLowerCase());
   }
 
   /// Get the index of the enum value
@@ -65,10 +65,10 @@ class EnumToString {
   ///
   /// Eg. final index = EnumToString.indexOf(TestEnum.values, "valueOne")
   /// index == 0 //true
-  static int indexOf<T>(List<T> enumValues, String value) =>
-      enumValues.indexOf(fromString<T>(enumValues, value));
+  static int indexOf<T>(List<T?> enumValues, String value) =>
+      enumValues.indexOf(fromString<T?>(enumValues, value));
 
-  static List<String> toList<T>(List<T> enumValues, {bool camelCase = false}) {
+  static List<String?>? toList<T>(List<T>? enumValues, {bool camelCase = false}) {
     if (enumValues == null) return null;
     final _enumList = enumValues
         .map((t) => !camelCase
@@ -86,10 +86,10 @@ class EnumToString {
   /// As with fromString it is not case sensitive
   ///
   /// Eg. EnumToString.fromList(TestEnum.values, ["valueOne", "value2"]
-  static List<T> fromList<T>(List<T> enumValues, List valueList) {
+  static List<T?>? fromList<T>(List<T>? enumValues, List? valueList) {
     if (valueList == null || enumValues == null) return null;
 
-    return List<T>.from(valueList
+    return List<T?>.from(valueList
         .map((item) => item == null ? null : fromString(enumValues, item)));
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,13 @@
+dependencies:
+  collection: ^1.15.0-nullsafety.4
 name: enum_to_string
 description: Better conversion of ENUMs to string. Dart has annoying EnumName.ValueName syntax when calling enum.toString, this package fixes that.
 version: 1.0.14
 homepage: https://github.com/rknell/flutterEnumsToString
 
 environment:
-  sdk: ">=2.1.0 <3.0.0"
+  sdk: '>=2.12.0-133.7.beta <3.0.0'
 
 dev_dependencies:
-  pedantic:
-  test:
+  pedantic: 1.10.0-nullsafety.3
+  test: 1.16.0-nullsafety.19

--- a/test/enum_to_string_test.dart
+++ b/test/enum_to_string_test.dart
@@ -111,22 +111,22 @@ void main() {
   });
 
   test('it should convert enum to string list', () {
-    expect(EnumToString.toList(TestEnum.values)[0], 'valueOne');
-    expect(EnumToString.toList(TestEnum.values)[1], 'Value2');
+    expect(EnumToString.toList(TestEnum.values)![0], 'valueOne');
+    expect(EnumToString.toList(TestEnum.values)![1], 'Value2');
     expect(EnumToString.toList(null), null);
   });
 
   test('it should also convert enum to string list', () {
     expect(
-        EnumToString.toList(TestEnum.values, camelCase: false)[0], 'valueOne');
-    expect(EnumToString.toList(TestEnum.values, camelCase: false)[1], 'Value2');
+        EnumToString.toList(TestEnum.values, camelCase: false)![0], 'valueOne');
+    expect(EnumToString.toList(TestEnum.values, camelCase: false)![1], 'Value2');
     expect(EnumToString.toList(null, camelCase: false), null);
   });
 
   test('it should convert enum to string list in camelCase', () {
     expect(
-        EnumToString.toList(TestEnum.values, camelCase: true)[0], 'Value one');
-    expect(EnumToString.toList(TestEnum.values, camelCase: true)[1], 'Value 2');
+        EnumToString.toList(TestEnum.values, camelCase: true)![0], 'Value one');
+    expect(EnumToString.toList(TestEnum.values, camelCase: true)![1], 'Value 2');
     expect(EnumToString.toList(null, camelCase: true), null);
   });
 

--- a/test/enum_to_string_test.dart
+++ b/test/enum_to_string_test.dart
@@ -44,16 +44,21 @@ void main() {
 
   test('it should convert camelCase enums to words', () {
     // ignore: deprecated_member_use_from_same_package
-    expect(EnumToString.parseCamelCase(TestEnum.valueOne), 'Value one');
+    expect(EnumToString.convertToString(TestEnum.valueOne, camelCase: true),
+        'Value one');
     // ignore: deprecated_member_use_from_same_package
-    expect(EnumToString.parseCamelCase(TestEnum.Value2), 'Value 2');
+    expect(EnumToString.convertToString(TestEnum.Value2, camelCase: true),
+        'Value 2');
     // ignore: deprecated_member_use_from_same_package
-    expect(EnumToString.parseCamelCase(TestEnum.testValue3), 'Test value 3');
+    expect(EnumToString.convertToString(TestEnum.testValue3, camelCase: true),
+        'Test value 3');
     // ignore: deprecated_member_use_from_same_package
-    expect(EnumToString.parseCamelCase(OtherEnumForTesting.helloImAnEnumValue),
+    expect(
+        EnumToString.convertToString(OtherEnumForTesting.helloImAnEnumValue,
+            camelCase: true),
         'Hello im an enum value');
     // ignore: deprecated_member_use_from_same_package
-    expect(EnumToString.parseCamelCase(null), null);
+    expect(EnumToString.convertToString(null), null);
   });
 
   test(
@@ -119,14 +124,16 @@ void main() {
   test('it should also convert enum to string list', () {
     expect(
         EnumToString.toList(TestEnum.values, camelCase: false)![0], 'valueOne');
-    expect(EnumToString.toList(TestEnum.values, camelCase: false)![1], 'Value2');
+    expect(
+        EnumToString.toList(TestEnum.values, camelCase: false)![1], 'Value2');
     expect(EnumToString.toList(null, camelCase: false), null);
   });
 
   test('it should convert enum to string list in camelCase', () {
     expect(
         EnumToString.toList(TestEnum.values, camelCase: true)![0], 'Value one');
-    expect(EnumToString.toList(TestEnum.values, camelCase: true)![1], 'Value 2');
+    expect(
+        EnumToString.toList(TestEnum.values, camelCase: true)![1], 'Value 2');
     expect(EnumToString.toList(null, camelCase: true), null);
   });
 


### PR DESCRIPTION
Related to #27 

- [x] Migrate to Null Safety 
- [x] Change deprecated method `parseCamelCase` to `convertToString` 

- All tests are passing. 


Happy to follow up if there are any issues. @rknell 