### PR TITLE
Update pubspec.yaml

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -4,7 +4,7 @@ version: 1.0.14-nullsafety.0
 homepage: https://github.com/rknell/flutterEnumsToString
 
 environment:
-  sdk: '>=2.12.0-133.6.beta <3.0.0'
+  sdk: '>=2.12.0-0 <3.0.0'
 
 dev_dependencies:
   pedantic: 1.10.0-nullsafety.3


### PR DESCRIPTION
Null safety is not correctly recognized with the current sdk constraint. 
Consider merging this pr and publish a new release on pub.