### PR TITLE
implement json parsing

### DIFF
--- a/lib/enum_json_parser.dart
+++ b/lib/enum_json_parser.dart
@@ -1,0 +1,9 @@
+class EnumJsonParser {
+  static T? parse<T>(List<T> enumValues, dynamic json) {
+    if (json != null && json is int && json >= 0 && json < enumValues.length) {
+      return enumValues[json];
+    }
+
+    return null;
+  }
+}

--- a/lib/enum_to_string.dart
+++ b/lib/enum_to_string.dart
@@ -2,6 +2,8 @@ library enum_to_string;
 
 import 'camel_case_to_words.dart';
 
+export 'enum_json_parser.dart';
+
 class EnumToString {
   static bool _isEnumItem(enumItem) {
     final split_enum = enumItem.toString().split('.');

--- a/test/enum_to_string_test.dart
+++ b/test/enum_to_string_test.dart
@@ -145,4 +145,33 @@ void main() {
         EnumToString.fromString(TestEnum.values, 'Value One', camelCase: true);
     expect(result, TestEnum.valueOne);
   });
+
+  group('enum_json_parser tests:', () {
+    final json = {
+      'val1': 0,
+      'val2': TestEnum.values.length,
+      'val3': -1,
+      'val4': null,
+    };
+    test('it should parse from json successfully', () {
+      final result =
+          EnumJsonParser.parse<TestEnum>(TestEnum.values, json['val1']);
+      expect(result, TestEnum.valueOne);
+    });
+    test('it should return null because the input is out of bounds', () {
+      final result1 =
+          EnumJsonParser.parse<TestEnum>(TestEnum.values, json['val2']);
+      final result2 =
+          EnumJsonParser.parse<TestEnum>(TestEnum.values, json['val3']);
+
+      expect(result1, null);
+      expect(result2, null);
+    });
+    test('it should return null because the input is null', () {
+      final result =
+          EnumJsonParser.parse<TestEnum>(TestEnum.values, json['val4']);
+
+      expect(result, null);
+    });
+  });
 }


### PR DESCRIPTION
usually, when parsing enum data from json, we may run into index or null exceptions. so I use this method each time I'm parsing enum value from json.